### PR TITLE
Add dependency info for face detect sample.

### DIFF
--- a/java/face_detection/pom.xml
+++ b/java/face_detection/pom.xml
@@ -27,6 +27,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
   </properties>
 
   <dependencies>
+    <!-- [START dependencies] -->
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-vision</artifactId>
@@ -37,6 +38,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
       <artifactId>google-api-client</artifactId>
       <version>1.21.0</version>
     </dependency>
+    <!-- [END dependencies] -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/python/face_detection/requirements.txt
+++ b/python/face_detection/requirements.txt
@@ -1,1 +1,2 @@
-google-api-python-client=1.3.2
+google-api-python-client==1.4.2
+Pillow==3.1.1


### PR DESCRIPTION
We were missing PIL (Pillow) for the Python face dectection sample. I tested, by using a new `virtualenv` and installing with `pip install -r requirements.txt`.

Also, I add region tags to the Java pom.xml so we can call out the dependencies in the quickstart tutorial.