### PR TITLE
Remove references to Python from Java READMEs.

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -36,7 +36,6 @@ libraries.
 
 This sample annotates an image with labels based on its content.
 
-- [Quickstart Walkthrough](https://cloud.google.com/vision/docs/label-tutorial) (Python)
 - [Java Code](https://github.com/GoogleCloudPlatform/cloud-vision/tree/master/java/label/)
 
 ### Face Detection

--- a/java/label/README.md
+++ b/java/label/README.md
@@ -36,8 +36,3 @@ To build and run the sample:
 mvn clean compile assembly:single
 java -cp target/label-1.0-SNAPSHOT-jar-with-dependencies.jar com.google.cloud.vision.samples.label.LabelApp ../../data/label/cat.jpg
 ```
-
-For more information about image labeling see the [Quickstart][quickstart]
-guide (Python).
-
-[quickstart]: https://cloud.google.com/vision/docs/face-tutorial


### PR DESCRIPTION
The label tutorial is going to be Python-only for the time-being.