### PR TITLE
Add workaround for bug with 1MB gzip requests.

### DIFF
--- a/android/CloudVision/app/src/main/java/sample/google/com/cloudvision/MainActivity.java
+++ b/android/CloudVision/app/src/main/java/sample/google/com/cloudvision/MainActivity.java
@@ -161,6 +161,8 @@ public class MainActivity extends AppCompatActivity {
 
                     Vision.Images.Annotate annotateRequest =
                             vision.images().annotate(batchAnnotateImagesRequest);
+                    // Due to a bug: requests to Vision API containing large images fail when GZipped.
+                    annotateRequest.setDisableGZipContent(true);
                     Log.d(TAG, "created Cloud Vision request object, sending request");
 
                     BatchAnnotateImagesResponse response = annotateRequest.execute();


### PR DESCRIPTION
Builds in Android Studio. Will test with an image once I get the camera working in the emulator.