### PR TITLE
java/text: use batch request for images.

### DIFF
--- a/java/text/README.md
+++ b/java/text/README.md
@@ -1,5 +1,18 @@
 # Text Detection using the Vision API
 
+This sample requires Java 8.
+
+## Download Maven
+
+This sample uses the [Apache Maven][maven] build system. Before getting started, be
+sure to [download][maven-download] and [install][maven-install] it. When you use
+Maven as described here, it will automatically download the needed client
+libraries.
+
+[maven]: https://maven.apache.org
+[maven-download]: https://maven.apache.org/download.cgi
+[maven-install]: https://maven.apache.org/install.html
+
 ## Introduction
 
 This example uses the [Cloud Vision API](https://cloud.google.com/vision/) to

--- a/java/text/src/main/java/com/google/cloud/vision/samples/text/ImageText.java
+++ b/java/text/src/main/java/com/google/cloud/vision/samples/text/ImageText.java
@@ -17,6 +17,7 @@
 package com.google.cloud.vision.samples.text;
 
 import com.google.api.services.vision.v1.model.EntityAnnotation;
+import com.google.api.services.vision.v1.model.Status;
 import com.google.auto.value.AutoValue;
 
 import java.nio.file.Path;
@@ -39,7 +40,7 @@ abstract class ImageText {
   public abstract List<EntityAnnotation> textAnnotations();
 
   @Nullable
-  public abstract Exception error();
+  public abstract Status error();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -47,7 +48,7 @@ abstract class ImageText {
 
     public abstract Builder textAnnotations(List<EntityAnnotation> ts);
 
-    public abstract Builder error(@Nullable Exception ex);
+    public abstract Builder error(@Nullable Status err);
 
     public abstract ImageText build();
   }

--- a/java/text/src/test/java/com/google/cloud/vision/samples/text/TextAppTest.java
+++ b/java/text/src/test/java/com/google/cloud/vision/samples/text/TextAppTest.java
@@ -32,6 +32,7 @@ import org.junit.runners.JUnit4;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -45,10 +46,11 @@ public class TextAppTest {
     TextApp appUnderTest = new TextApp(TextApp.getVisionService(), null /* index */);
 
     // Act
-    ImageText image = appUnderTest.detectText(Paths.get("../../data/text/wakeupcat.jpg"));
+    List<ImageText> image =
+        appUnderTest.detectText(ImmutableList.<Path>of(Paths.get("../../data/text/wakeupcat.jpg")));
 
     // Assert
-    assertThat(image.path().toString())
+    assertThat(image.get(0).path().toString())
         .named("wakeupcat.jpg path")
         .isEqualTo("../../data/text/wakeupcat.jpg");
   }
@@ -56,10 +58,11 @@ public class TextAppTest {
   @Test public void extractDescriptions_withImage_returnsText() throws Exception {
     // Arrange
     TextApp appUnderTest = new TextApp(TextApp.getVisionService(), null /* index */);
-    ImageText image = appUnderTest.detectText(Paths.get("../../data/text/wakeupcat.jpg"));
+    List<ImageText> image =
+        appUnderTest.detectText(ImmutableList.<Path>of(Paths.get("../../data/text/wakeupcat.jpg")));
 
     // Act
-    Word word = appUnderTest.extractDescriptions(image);
+    Word word = appUnderTest.extractDescriptions(image.get(0));
 
     // Assert
     assertThat(word.path().toString())


### PR DESCRIPTION
Sister change to https://github.com/GoogleCloudPlatform/cloud-vision/pull/18 for Java instead of Python, this time.

Since I have been using some Java 8 features in this sample, I also update the README to document that, plus pull in the Maven Installation header that we've had in the other Java samples.