### PR TITLE
ios: add shared schemes to projects.

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -18,3 +18,4 @@ DerivedData
 .idea/
 # Pods
 **/Pods
+Podfile.lock

--- a/ios/Objective-C/imagepicker-objc.xcodeproj/xcshareddata/xcschemes/imagepicker-objc.xcscheme
+++ b/ios/Objective-C/imagepicker-objc.xcodeproj/xcshareddata/xcschemes/imagepicker-objc.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1B1684421C3B164200220B6E"
+               BuildableName = "imagepicker-objc.app"
+               BlueprintName = "imagepicker-objc"
+               ReferencedContainer = "container:imagepicker-objc.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1B16845B1C3B164200220B6E"
+               BuildableName = "imagepicker-objcTests.xctest"
+               BlueprintName = "imagepicker-objcTests"
+               ReferencedContainer = "container:imagepicker-objc.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1B1684661C3B164200220B6E"
+               BuildableName = "imagepicker-objcUITests.xctest"
+               BlueprintName = "imagepicker-objcUITests"
+               ReferencedContainer = "container:imagepicker-objc.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1B1684421C3B164200220B6E"
+            BuildableName = "imagepicker-objc.app"
+            BlueprintName = "imagepicker-objc"
+            ReferencedContainer = "container:imagepicker-objc.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1B1684421C3B164200220B6E"
+            BuildableName = "imagepicker-objc.app"
+            BlueprintName = "imagepicker-objc"
+            ReferencedContainer = "container:imagepicker-objc.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1B1684421C3B164200220B6E"
+            BuildableName = "imagepicker-objc.app"
+            BlueprintName = "imagepicker-objc"
+            ReferencedContainer = "container:imagepicker-objc.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Swift/imagepicker.xcodeproj/xcshareddata/xcschemes/imagepicker.xcscheme
+++ b/ios/Swift/imagepicker.xcodeproj/xcshareddata/xcschemes/imagepicker.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1BFC2E791BF1AA7300885EBB"
+               BuildableName = "imagepicker.app"
+               BlueprintName = "imagepicker"
+               ReferencedContainer = "container:imagepicker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1BFC2E8D1BF1AA7300885EBB"
+               BuildableName = "imagepickerTests.xctest"
+               BlueprintName = "imagepickerTests"
+               ReferencedContainer = "container:imagepicker.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1BFC2E981BF1AA7300885EBB"
+               BuildableName = "imagepickerUITests.xctest"
+               BlueprintName = "imagepickerUITests"
+               ReferencedContainer = "container:imagepicker.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1BFC2E791BF1AA7300885EBB"
+            BuildableName = "imagepicker.app"
+            BlueprintName = "imagepicker"
+            ReferencedContainer = "container:imagepicker.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1BFC2E791BF1AA7300885EBB"
+            BuildableName = "imagepicker.app"
+            BlueprintName = "imagepicker"
+            ReferencedContainer = "container:imagepicker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1BFC2E791BF1AA7300885EBB"
+            BuildableName = "imagepicker.app"
+            BlueprintName = "imagepicker"
+            ReferencedContainer = "container:imagepicker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This allows the projects to be built from the command line using [xctool][xctool]. This will let us verify these builds from Travis, as the protobuf project does [here][travis.sh].

[xctool]: https://github.com/facebook/xctool
[travis.sh]: https://github.com/google/protobuf/blob/master/travis.sh