### PR TITLE
java: fix tests for partial API failures.

### DIFF
--- a/java/face_detection/src/main/java/com/google/cloud/vision/samples/facedetect/FaceDetectApp.java
+++ b/java/face_detection/src/main/java/com/google/cloud/vision/samples/facedetect/FaceDetectApp.java
@@ -24,6 +24,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.vision.v1.Vision;
 import com.google.api.services.vision.v1.VisionScopes;
 import com.google.api.services.vision.v1.model.AnnotateImageRequest;
+import com.google.api.services.vision.v1.model.AnnotateImageResponse;
 import com.google.api.services.vision.v1.model.BatchAnnotateImagesRequest;
 import com.google.api.services.vision.v1.model.BatchAnnotateImagesResponse;
 import com.google.api.services.vision.v1.model.FaceAnnotation;
@@ -130,8 +131,16 @@ public class FaceDetectApp {
     // Due to a bug: requests to Vision API containing large images fail when GZipped.
     annotate.setDisableGZipContent(true);
 
-    BatchAnnotateImagesResponse response = annotate.execute();
-    return response.getResponses().get(0).getFaceAnnotations();
+    BatchAnnotateImagesResponse batchResponse = annotate.execute();
+    assert batchResponse.getResponses().size() == 1;
+    AnnotateImageResponse response = batchResponse.getResponses().get(0);
+    if (response.getFaceAnnotations() == null) {
+      throw new IOException(
+          response.getError() != null
+              ? response.getError().getMessage()
+              : "Unknown error getting image annotations");
+    }
+    return response.getFaceAnnotations();
   }
   // [END detect_face]
 

--- a/java/face_detection/src/test/java/com/google/cloud/vision/samples/facedetect/FaceDetectAppTest.java
+++ b/java/face_detection/src/test/java/com/google/cloud/vision/samples/facedetect/FaceDetectAppTest.java
@@ -32,6 +32,7 @@ import org.junit.runners.JUnit4;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -62,11 +63,11 @@ public class FaceDetectAppTest {
 
     try {
       appUnderTest.detectFaces(Paths.get("../../data/bad.txt"), MAX_RESULTS);
-      fail("Expected GoogleJsonResponseException");
-    } catch (GoogleJsonResponseException expected) {
-      assertThat(expected.getDetails().getCode())
-          .named("GoogleJsonResponseException Error Code")
-          .isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+      fail("Expected IOException");
+    } catch (IOException expected) {
+      assertThat(expected.getMessage().toLowerCase())
+          .named("IOException message")
+          .contains("malformed request");
     }
   }
 

--- a/java/label/src/main/java/com/google/cloud/vision/samples/label/LabelApp.java
+++ b/java/label/src/main/java/com/google/cloud/vision/samples/label/LabelApp.java
@@ -24,6 +24,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.vision.v1.Vision;
 import com.google.api.services.vision.v1.VisionScopes;
 import com.google.api.services.vision.v1.model.AnnotateImageRequest;
+import com.google.api.services.vision.v1.model.AnnotateImageResponse;
 import com.google.api.services.vision.v1.model.BatchAnnotateImagesRequest;
 import com.google.api.services.vision.v1.model.BatchAnnotateImagesResponse;
 import com.google.api.services.vision.v1.model.EntityAnnotation;
@@ -132,8 +133,16 @@ public class LabelApp {
     // [END construct_request]
 
     // [START parse_response]
-    BatchAnnotateImagesResponse response = annotate.execute();
-    return response.getResponses().get(0).getLabelAnnotations();
+    BatchAnnotateImagesResponse batchResponse = annotate.execute();
+    assert batchResponse.getResponses().size() == 1;
+    AnnotateImageResponse response = batchResponse.getResponses().get(0);
+    if (response.getLabelAnnotations() == null) {
+      throw new IOException(
+          response.getError() != null
+              ? response.getError().getMessage()
+              : "Unknown error getting image annotations");
+    }
+    return response.getLabelAnnotations();
     // [END parse_response]
   }
 }

--- a/java/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppTest.java
+++ b/java/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Paths;
 import java.util.List;
@@ -63,11 +64,11 @@ public class LabelAppTest {
 
     try {
       appUnderTest.labelImage(Paths.get("../../data/bad.txt"), MAX_LABELS);
-      fail("Expected GoogleJsonResponseException");
-    } catch (GoogleJsonResponseException expected) {
-      assertThat(expected.getDetails().getCode())
-          .named("GoogleJsonResponseException Error Code")
-          .isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+      fail("Expected IOException");
+    } catch (IOException expected) {
+      assertThat(expected.getMessage().toLowerCase())
+          .named("IOException message")
+          .contains("malformed request");
     }
   }
 

--- a/java/landmark_detection/src/main/java/com/google/cloud/vision/samples/landmarkdetection/DetectLandmark.java
+++ b/java/landmark_detection/src/main/java/com/google/cloud/vision/samples/landmarkdetection/DetectLandmark.java
@@ -24,6 +24,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.vision.v1.Vision;
 import com.google.api.services.vision.v1.VisionScopes;
 import com.google.api.services.vision.v1.model.AnnotateImageRequest;
+import com.google.api.services.vision.v1.model.AnnotateImageResponse;
 import com.google.api.services.vision.v1.model.BatchAnnotateImagesRequest;
 import com.google.api.services.vision.v1.model.BatchAnnotateImagesResponse;
 import com.google.api.services.vision.v1.model.EntityAnnotation;
@@ -115,8 +116,16 @@ public class DetectLandmark {
         vision.images()
             .annotate(new BatchAnnotateImagesRequest().setRequests(ImmutableList.of(request)));
 
-    BatchAnnotateImagesResponse response = annotate.execute();
-    return response.getResponses().get(0).getLandmarkAnnotations();
+    BatchAnnotateImagesResponse batchResponse = annotate.execute();
+    assert batchResponse.getResponses().size() == 1;
+    AnnotateImageResponse response = batchResponse.getResponses().get(0);
+    if (response.getLandmarkAnnotations() == null) {
+      throw new IOException(
+          response.getError() != null
+              ? response.getError().getMessage()
+              : "Unknown error getting image annotations");
+    }
+    return response.getLandmarkAnnotations();
   }
   // [END detect_gcs_object]
 }

--- a/java/landmark_detection/src/test/java/com/google/cloud/vision/samples/landmarkdetection/DetectLandmarkTest.java
+++ b/java/landmark_detection/src/test/java/com/google/cloud/vision/samples/landmarkdetection/DetectLandmarkTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.IOException;
 import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 
@@ -58,11 +59,9 @@ public class DetectLandmarkTest {
 
     try {
       appUnderTest.identifyLandmark(LANDMARK_URI + "/nonexistent.jpg", MAX_RESULTS);
-      fail("Expected GoogleJsonResponseException");
-    } catch (GoogleJsonResponseException expected) {
-      assertThat(expected.getDetails().getCode())
-          .named("GoogleJsonResponseException Error Code")
-          .isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+      fail("Expected IOException");
+    } catch (IOException expected) {
+      assertThat(expected.getMessage()).named("IOException message").contains("OBJECT_NOT_FOUND");
     }
   }
 
@@ -71,11 +70,9 @@ public class DetectLandmarkTest {
 
     try {
       appUnderTest.identifyLandmark(PRIVATE_LANDMARK_URI, MAX_RESULTS);
-      fail("Expected GoogleJsonResponseException");
-    } catch (GoogleJsonResponseException expected) {
-      assertThat(expected.getDetails().getCode())
-          .named("GoogleJsonResponseException Error Code")
-          .isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+      fail("Expected IOException");
+    } catch (IOException expected) {
+      assertThat(expected.getMessage()).named("IOException message").contains("ACCESS_DENIED");
     }
   }
 }


### PR DESCRIPTION
The API was changed to not return an HTTP error code in these cases, so
we have to manually check for errors, instead.