### PR TITLE
Fix ImportError: No module named locked_file

### DIFF
--- a/python/face_detection/requirements.txt
+++ b/python/face_detection/requirements.txt
@@ -1,2 +1,2 @@
-google-api-python-client==1.4.2
+google-api-python-client==1.5.0
 Pillow==3.1.1


### PR DESCRIPTION
The old api client would throw this error:

File "/local/lib/python2.7/site-packages/googleapiclient/discovery_cache/file_cache.py", line 3
<module>
  from oauth2client.locked_file import LockedFile
ImportError: No module named locked_file