### PR TITLE
ios: populate the header with the bundle identitfier.

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -18,4 +18,3 @@ DerivedData
 .idea/
 # Pods
 **/Pods
-Podfile.lock

--- a/ios/Objective-C/imagepicker-objc.xcodeproj/project.pbxproj
+++ b/ios/Objective-C/imagepicker-objc.xcodeproj/project.pbxproj
@@ -423,7 +423,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "imagepicker-objc/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.sara.woot.imagepicker-objc";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.cloud.vision.sample.imagepicker-objc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -434,7 +434,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "imagepicker-objc/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.sara.woot.imagepicker-objc";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.cloud.vision.sample.imagepicker-objc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/ios/Objective-C/imagepicker-objc/ImagePickerViewController.m
+++ b/ios/Objective-C/imagepicker-objc/ImagePickerViewController.m
@@ -77,6 +77,9 @@
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     [request setHTTPMethod: @"POST"];
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    [request
+     addValue:[[NSBundle mainBundle] bundleIdentifier]
+     forHTTPHeaderField:@"X-Ios-Bundle-Identifier"];
     
     // Build our API request
     NSDictionary *paramsDictionary =

--- a/ios/Swift/Podfile.lock
+++ b/ios/Swift/Podfile.lock
@@ -1,0 +1,19 @@
+PODS:
+  - SwiftyJSON (2.3.2)
+
+DEPENDENCIES:
+  - SwiftyJSON (from `https://github.com/SwiftyJSON/SwiftyJSON.git`)
+
+EXTERNAL SOURCES:
+  SwiftyJSON:
+    :git: https://github.com/SwiftyJSON/SwiftyJSON.git
+
+CHECKOUT OPTIONS:
+  SwiftyJSON:
+    :commit: 42bdb102d2624b143c07850ebdc1537d5b6579b6
+    :git: https://github.com/SwiftyJSON/SwiftyJSON.git
+
+SPEC CHECKSUMS:
+  SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
+
+COCOAPODS: 0.39.0

--- a/ios/Swift/imagepicker.xcodeproj/project.pbxproj
+++ b/ios/Swift/imagepicker.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 				);
 				INFOPLIST_FILE = imagepicker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sara.woot.imagepicker;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.cloud.vision.sample.imagepicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};
@@ -507,7 +507,7 @@
 				);
 				INFOPLIST_FILE = imagepicker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sara.woot.imagepicker;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.cloud.vision.sample.imagepicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};

--- a/ios/Swift/imagepicker/ImagePickerViewController.swift
+++ b/ios/Swift/imagepicker/ImagePickerViewController.swift
@@ -24,7 +24,6 @@ class ViewController: UIViewController, UIImagePickerControllerDelegate, UINavig
     @IBOutlet weak var faceResults: UITextView!
     
     var API_KEY = "YOUR_API_KEY"
-    
 
     @IBAction func loadImageButtonTapped(sender: UIButton) {
         imagePicker.allowsEditing = false
@@ -73,9 +72,13 @@ class ViewController: UIViewController, UIImagePickerControllerDelegate, UINavig
     
     func createRequest(imageData: String) {
         // Create our request URL
-        let request = NSMutableURLRequest(URL: NSURL(string: "https://vision.googleapis.com/v1/images:annotate?key=\(API_KEY)")!)
+        let request = NSMutableURLRequest(
+            URL: NSURL(string: "https://vision.googleapis.com/v1/images:annotate?key=\(API_KEY)")!)
         request.HTTPMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(
+            NSBundle.mainBundle().bundleIdentifier ?? "",
+            forHTTPHeaderField: "X-Ios-Bundle-Identifier")
         
         // Build our API request
         let jsonRequest: [String: AnyObject] = [


### PR DESCRIPTION
This will allow using iOS API keys that are tied to the bundle identifier. I also update the bundle identifier to be more official.

CocoaPods recommend always keeping the Podfile.lock in version control, so I add that, too. https://guides.cocoapods.org/using/using-cocoapods.html.

Fixes #16.