### PR TITLE
java/travis: run unit tests w/ missing credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ os:
 - linux
 before_install:
 - openssl aes-256-cbc -K $encrypted_49d9325ac449_key -iv $encrypted_49d9325ac449_iv
-  -in client-secret.json.enc -out client-secret.json -d
+  -in client-secret.json.enc -out client-secret.json -d || true
 script:
 - ./travis.sh $CONFIG
 env:

--- a/java/face_detection/pom.xml
+++ b/java/face_detection/pom.xml
@@ -14,8 +14,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -24,6 +23,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
   <dependencies>
@@ -88,6 +88,29 @@ Copyright 2016 Google Inc. All Rights Reserved.
         </configuration>
       </plugin>
       <plugin>
+        <!-- Unit tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- Integration / system tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
@@ -96,6 +119,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
           <consoleOutput>true</consoleOutput>
           <failOnViolation>true</failOnViolation>
           <failsOnError>true</failsOnError>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
         <executions>
           <execution><goals><goal>check</goal></goals></execution>

--- a/java/face_detection/src/test/java/com/google/cloud/vision/samples/facedetect/FaceDetectAppIT.java
+++ b/java/face_detection/src/test/java/com/google/cloud/vision/samples/facedetect/FaceDetectAppIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.vision.samples.facedetect;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.api.services.vision.v1.model.FaceAnnotation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Integration (system) tests for {@link FaceDetectApp}.
+ */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class FaceDetectAppIT {
+  private static final int MAX_RESULTS = 3;
+
+  private FaceDetectApp appUnderTest;
+
+  @Before public void setUp() throws Exception {
+    appUnderTest = new FaceDetectApp(FaceDetectApp.getVisionService());
+  }
+
+  @Test public void detectFaces_withFace_returnsAtLeastOneFace() throws Exception {
+    List<FaceAnnotation> faces =
+        appUnderTest.detectFaces(Paths.get("../../data/face_detection/face.jpg"), MAX_RESULTS);
+
+    assertThat(faces).named("face.jpg faces").isNotEmpty();
+    assertThat(faces.get(0).getFdBoundingPoly().getVertices())
+        .named("face.jpg face #0 FdBoundingPoly Vertices")
+        .isNotEmpty();
+  }
+
+  @Test public void detectFaces_badImage_throwsException() throws Exception {
+    try {
+      appUnderTest.detectFaces(Paths.get("../../data/bad.txt"), MAX_RESULTS);
+      fail("Expected IOException");
+    } catch (IOException expected) {
+      assertThat(expected.getMessage().toLowerCase())
+          .named("IOException message")
+          .contains("malformed request");
+    }
+  }
+}

--- a/java/face_detection/src/test/java/com/google/cloud/vision/samples/facedetect/FaceDetectAppTest.java
+++ b/java/face_detection/src/test/java/com/google/cloud/vision/samples/facedetect/FaceDetectAppTest.java
@@ -17,60 +17,23 @@
 package com.google.cloud.vision.samples.facedetect;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.vision.v1.model.FaceAnnotation;
 import com.google.api.services.vision.v1.model.BoundingPoly;
+import com.google.api.services.vision.v1.model.FaceAnnotation;
 import com.google.api.services.vision.v1.model.Vertex;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.List;
 
-import javax.servlet.http.HttpServletResponse;
-
-/** Unit tests for {@link FaceDetectApp}. */
+/**
+ * Unit tests for {@link FaceDetectApp}.
+ */
 @RunWith(JUnit4.class)
 public class FaceDetectAppTest {
-  private static final int MAX_RESULTS = 3;
-
-  @Test public void detectFaces_withFace_returnsAtLeastOneFace() throws Exception {
-    // Arrange
-    FaceDetectApp appUnderTest = new FaceDetectApp(FaceDetectApp.getVisionService());
-
-    // Act
-    List<FaceAnnotation> faces =
-        appUnderTest.detectFaces(Paths.get("../../data/face_detection/face.jpg"), MAX_RESULTS);
-
-    // Assert
-    assertThat(faces).named("face.jpg faces").isNotEmpty();
-    assertThat(faces.get(0).getFdBoundingPoly().getVertices())
-        .named("face.jpg face #0 FdBoundingPoly Vertices")
-        .isNotEmpty();
-  }
-
-  @Test public void detectFaces_badImage_throwsException() throws Exception {
-    FaceDetectApp appUnderTest = new FaceDetectApp(FaceDetectApp.getVisionService());
-
-    try {
-      appUnderTest.detectFaces(Paths.get("../../data/bad.txt"), MAX_RESULTS);
-      fail("Expected IOException");
-    } catch (IOException expected) {
-      assertThat(expected.getMessage().toLowerCase())
-          .named("IOException message")
-          .contains("malformed request");
-    }
-  }
-
   @Test public void annotateWithFaces_manyFaces_outlinesFaces() throws Exception {
     // Arrange
     ImmutableList<FaceAnnotation> faces =

--- a/java/google-checks.xml
+++ b/java/google-checks.xml
@@ -30,6 +30,8 @@
         </module>
 
     <module name="TreeWalker">
+        <!-- Make @SuppressWarnings available to checkstyle http://stackoverflow.com/a/22556386/101923 -->
+        <module name="SuppressWarningsHolder" />
         <module name="UnusedImports"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -179,6 +181,7 @@
         </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
+            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
@@ -198,4 +201,7 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
     </module>
+
+    <!-- Allow silencing rules with annotations http://stackoverflow.com/a/22556386/101923 -->
+    <module name="SuppressWarningsFilter" />
 </module>

--- a/java/label/pom.xml
+++ b/java/label/pom.xml
@@ -24,6 +24,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
   <dependencies>
@@ -86,6 +87,29 @@ Copyright 2016 Google Inc. All Rights Reserved.
         </configuration>
       </plugin>
       <plugin>
+        <!-- Unit tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- Integration / system tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
@@ -94,6 +118,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
           <consoleOutput>true</consoleOutput>
           <failOnViolation>true</failOnViolation>
           <failsOnError>true</failsOnError>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
         <executions>
           <execution><goals><goal>check</goal></goals></execution>

--- a/java/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppIT.java
+++ b/java/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.vision.samples.label;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.api.services.vision.v1.model.EntityAnnotation;
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Integration (system) tests for {@link LabelApp}.
+ */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class LabelAppIT {
+  private static final int MAX_LABELS = 3;
+
+  private LabelApp appUnderTest;
+
+  @Before public void setUp() throws Exception {
+    appUnderTest = new LabelApp(LabelApp.getVisionService());
+  }
+
+  @Test public void labelImage_cat_returnsCatDescription() throws Exception {
+    List<EntityAnnotation> labels =
+        appUnderTest.labelImage(Paths.get("../../data/label/cat.jpg"), MAX_LABELS);
+
+    ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+    for (EntityAnnotation label : labels) {
+      builder.add(label.getDescription());
+    }
+    ImmutableSet<String> descriptions = builder.build();
+
+    assertThat(descriptions).named("cat.jpg labels").contains("cat");
+  }
+
+  @Test public void labelImage_badImage_throwsException() throws Exception {
+    try {
+      appUnderTest.labelImage(Paths.get("../../data/bad.txt"), MAX_LABELS);
+      fail("Expected IOException");
+    } catch (IOException expected) {
+      assertThat(expected.getMessage().toLowerCase())
+          .named("IOException message")
+          .contains("malformed request");
+    }
+  }
+}

--- a/java/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppTest.java
+++ b/java/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppTest.java
@@ -17,60 +17,23 @@
 package com.google.cloud.vision.samples.label;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.vision.v1.model.EntityAnnotation;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Paths;
-import java.util.List;
 
-import javax.servlet.http.HttpServletResponse;
-
-/** Unit tests for {@link LabelApp}. */
+/**
+ * Unit tests for {@link LabelApp}.
+ */
 @RunWith(JUnit4.class)
 public class LabelAppTest {
-  private static final int MAX_LABELS = 3;
-
-  @Test public void labelImage_cat_returnsCatDescription() throws Exception {
-    // Arrange
-    LabelApp appUnderTest = new LabelApp(LabelApp.getVisionService());
-
-    // Act
-    List<EntityAnnotation> labels =
-        appUnderTest.labelImage(Paths.get("../../data/label/cat.jpg"), MAX_LABELS);
-
-    // Assert
-    ImmutableSet.Builder<String> builder = ImmutableSet.builder();
-    for (EntityAnnotation label : labels) {
-      builder.add(label.getDescription());
-    }
-    ImmutableSet<String> descriptions = builder.build();
-
-    assertThat(descriptions).named("cat.jpg labels").contains("cat");
-  }
-
-  @Test public void labelImage_badImage_throwsException() throws Exception {
-    LabelApp appUnderTest = new LabelApp(LabelApp.getVisionService());
-
-    try {
-      appUnderTest.labelImage(Paths.get("../../data/bad.txt"), MAX_LABELS);
-      fail("Expected IOException");
-    } catch (IOException expected) {
-      assertThat(expected.getMessage().toLowerCase())
-          .named("IOException message")
-          .contains("malformed request");
-    }
-  }
 
   @Test public void printLabels_emptyList_printsNoLabelsFound() throws Exception {
     // Arrange

--- a/java/landmark_detection/pom.xml
+++ b/java/landmark_detection/pom.xml
@@ -24,6 +24,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
   <dependencies>
@@ -84,6 +85,29 @@ Copyright 2016 Google Inc. All Rights Reserved.
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
         </configuration>
+      </plugin>
+      <plugin>
+        <!-- Unit tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- Integration / system tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/java/landmark_detection/src/test/java/com/google/cloud/vision/samples/landmarkdetection/DetectLandmarkIT.java
+++ b/java/landmark_detection/src/test/java/com/google/cloud/vision/samples/landmarkdetection/DetectLandmarkIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.vision.v1.model.EntityAnnotation;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,23 +32,25 @@ import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Unit tests for {@link DetectLandmark}.
+ * Integration (system) tests for {@link DetectLandmark}.
  **/
 @RunWith(JUnit4.class)
-public class DetectLandmarkTest {
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class DetectLandmarkIT {
   private static final int MAX_RESULTS = 3;
   private static final String LANDMARK_URI = "gs://cloud-samples-tests/vision/water.jpg";
   private static final String PRIVATE_LANDMARK_URI =
       "gs://cloud-samples-tests/vision/water-private.jpg";
 
-  @Test public void identifyLandmark_withLandmark_returnsKnownLandmark() throws Exception {
-    // Arrange
-    DetectLandmark appUnderTest = new DetectLandmark(DetectLandmark.getVisionService());
+  private DetectLandmark appUnderTest;
 
-    // Act
+  @Before public void setUp() throws Exception {
+    appUnderTest = new DetectLandmark(DetectLandmark.getVisionService());
+  }
+
+  @Test public void identifyLandmark_withLandmark_returnsKnownLandmark() throws Exception {
     List<EntityAnnotation> landmarks = appUnderTest.identifyLandmark(LANDMARK_URI, MAX_RESULTS);
 
-    // Assert
     assertThat(landmarks).named("water.jpg landmarks").isNotEmpty();
     assertThat(landmarks.get(0).getDescription())
         .named("water.jpg landmark #0 description")
@@ -55,8 +58,6 @@ public class DetectLandmarkTest {
   }
 
   @Test public void identifyLandmark_noImage_throwsNotFound() throws Exception {
-    DetectLandmark appUnderTest = new DetectLandmark(DetectLandmark.getVisionService());
-
     try {
       appUnderTest.identifyLandmark(LANDMARK_URI + "/nonexistent.jpg", MAX_RESULTS);
       fail("Expected IOException");
@@ -66,8 +67,6 @@ public class DetectLandmarkTest {
   }
 
   @Test public void identifyLandmark_noImage_throwsForbidden() throws Exception {
-    DetectLandmark appUnderTest = new DetectLandmark(DetectLandmark.getVisionService());
-
     try {
       appUnderTest.identifyLandmark(PRIVATE_LANDMARK_URI, MAX_RESULTS);
       fail("Expected IOException");
@@ -76,4 +75,3 @@ public class DetectLandmarkTest {
     }
   }
 }
-

--- a/java/text/pom.xml
+++ b/java/text/pom.xml
@@ -24,6 +24,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
   <dependencies>
@@ -102,6 +103,29 @@ Copyright 2016 Google Inc. All Rights Reserved.
         </configuration>
       </plugin>
       <plugin>
+        <!-- Unit tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- Integration / system tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
@@ -111,6 +135,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
           <consoleOutput>true</consoleOutput>
           <failOnViolation>true</failOnViolation>
           <failsOnError>true</failsOnError>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
         <executions>
           <execution><goals><goal>check</goal></goals></execution>

--- a/java/text/src/test/java/com/google/cloud/vision/samples/text/TextAppIT.java
+++ b/java/text/src/test/java/com/google/cloud/vision/samples/text/TextAppIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.vision.samples.text;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Integration (system) tests for {@link TextApp}.
+ **/
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class TextAppIT {
+  private TextApp appUnderTest;
+
+  @Before public void setUp() throws Exception {
+    appUnderTest = new TextApp(TextApp.getVisionService(), null /* index */);
+  }
+
+  @Test public void extractDescriptions_withImage_returnsText() throws Exception {
+    // Arrange
+    List<ImageText> image =
+        appUnderTest.detectText(ImmutableList.<Path>of(Paths.get("../../data/text/wakeupcat.jpg")));
+
+    // Act
+    Word word = appUnderTest.extractDescriptions(image.get(0));
+
+    // Assert
+    assertThat(word.path().toString())
+        .named("wakeupcat.jpg path")
+        .isEqualTo("../../data/text/wakeupcat.jpg");
+    assertThat(word.word().toLowerCase()).named("wakeupcat.jpg word").contains("wake");
+    assertThat(word.word().toLowerCase()).named("wakeupcat.jpg word").contains("up");
+    assertThat(word.word().toLowerCase()).named("wakeupcat.jpg word").contains("human");
+  }
+}

--- a/travis.sh
+++ b/travis.sh
@@ -48,11 +48,11 @@ build_java() {
   for jdir in $(ls -d java/*/); do
     (
     cd "${jdir}" && mvn clean compile assembly:single
-    if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
-      echo "Secrets not available, skipping tests."
-      mvn clean verify -DskipTests
-    else
+    if [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
       mvn clean verify
+    else
+      echo "Application Credentials not available, skipping integration tests."
+      mvn clean verify -DskipITs
     fi
     )
   done


### PR DESCRIPTION
In our travis.yml, I ignore the failure to extract the secret
credentials file. Extraction fails for all external pull requests: we
don't want Travis to just stop there, we want to run as many tests as we
are able.

I split the Java tests into separate unit tests and integration (system)
tests. This way, we can skip the integration tests for external pull
requests, but still run everything else (including checkstyle).

I noticed that I had a bunch of unused imports in the test files, so I
made checkstyle run on the test files, as well. The way the integration
test runner knows that test is an integration test is with the IT
suffix. Since this violates the checkstyle rules, I add an annotation to
ignore just this rule in those classes.

CC @jerjou @amygdala 