### PR TITLE
go/travis: add config to run Go tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ env:
   matrix:
   - CONFIG=android_jdk8
   - CONFIG=android_oracle8
+  - CONFIG=go
   - CONFIG=java_jdk8
   - CONFIG=java_oracle8
   - CONFIG=php

--- a/go/label/label_test.go
+++ b/go/label/label_test.go
@@ -22,6 +22,12 @@ import (
 )
 
 func TestLabel(t *testing.T) {
+	// Skip tests that actually hit the API in short mode. We run with the
+	// -test.short flag in Travis from external pull requests because the
+	// credentials are not available.
+	if testing.Short() {
+		return
+	}
 	assert := assert.New(t)
 	creds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	const filename = "../../data/label/cat.jpg"


### PR DESCRIPTION
Adds Go support for issue #25.

Depends on #36 so that should be merged first.