### PR TITLE
Remove unused code.

### DIFF
--- a/android/CloudVision/app/src/main/java/sample/google/com/cloudvision/MainActivity.java
+++ b/android/CloudVision/app/src/main/java/sample/google/com/cloudvision/MainActivity.java
@@ -96,7 +96,6 @@ public class MainActivity extends AppCompatActivity {
     public void startCamera() {
         if (PermissionUtils.requestPermission(this, CAMERA_PERMISSIONS_REQUEST, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.CAMERA)) {
             Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-            File dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
             intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(getCameraFile()));
             startActivityForResult(intent, CAMERA_IMAGE_REQUEST);
         }


### PR DESCRIPTION
The call to get the File object is not used in startCamera(), also getCameraFile() is taking care of getting the File, no need to make the same call in startCamera()