### PR TITLE
Package config.json in Chrome extension, bump version to 0.0.9

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Cloud Vision",
   "description": "Adds a right-click menu item to images to detect text, labels and faces.",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "permissions": [
     "clipboardWrite",
     "contextMenus",

--- a/chrome-extension/package.sh
+++ b/chrome-extension/package.sh
@@ -14,4 +14,4 @@
 #
 
 #! /bin/bash
-zip -r ext.zip background.js manifest.json images/
+zip -r ext.zip background.js manifest.json config.json images/


### PR DESCRIPTION
The previous change to factor out the API key into a config.json neglected to include that file in the packaged extension, so 0.0.8 of the extension was broken for users.