### PR TITLE
Update java repo tools to latest version

### DIFF
--- a/java/java-repo-tools/README.md
+++ b/java/java-repo-tools/README.md
@@ -41,6 +41,19 @@ git checkout master
 # Making a new branch ia optional, but recommended to send a pull request to
 # start using java-repo-tools.
 git checkout -b use-java-repo-tools
+```
+
+So that we can pull future updates from the `java-repo-tools` repository, we
+merge histories. This way we won't get unnecessary conflicts when pulling changes
+in.
+
+```
+git merge -s ours --no-commit java-repo-tools/master
+```
+
+Finally, read the `java-repo-tools` into a subtree.
+
+```
 git read-tree --prefix=java-repo-tools/ -u java-repo-tools
 ```
 
@@ -82,17 +95,13 @@ now-redundant plugin information.
 If you haven't done this before, run
 
 ```
-git remote add java-repo-tools
-git@github.com:GoogleCloudPlatform/java-repo-tools.git
-git fetch java-repo-tools master
-# Optional, but it makes pushing changes upstream easier.
-git checkout -b java-repo-tools java-repo-tools/master
+git remote add java-repo-tools git@github.com:GoogleCloudPlatform/java-repo-tools.git
 ```
 
 To detect if you have changes in the directory, run
 
 ```
-git fetch java-repo-tools
+git fetch java-repo-tools master
 git diff-tree -p HEAD:java-repo-tools/ java-repo-tools/master
 ```
 
@@ -111,33 +120,17 @@ directory.)
 To update the `java-repo-tools` directory, if you haven't done this before, run
 
 ```
-git remote add java-repo-tools
-git@github.com:GoogleCloudPlatform/java-repo-tools.git
-git fetch java-repo-tools master
-git checkout -b java-repo-tools java-repo-tools/master
+git remote add java-repo-tools git@github.com:GoogleCloudPlatform/java-repo-tools.git
 ```
 
-To pull the changes when in this branch run
-
-```
-git pull java-repo-tools master
-```
-
-To pull the changes back from upstream:
-
-```
-git checkout java-repo-tools
-git pull java-repo-tools master
-```
-
-Pull them into the main code.
+To pull the latest changes from this `java-repo-tools` repository, run:
 
 ```
 git checkout master
 # Making a new branch is optional, but recommended to send a pull request for
 # update.
 git checkout -b update-java-repo-tools
-git merge --squash -Xsubtree=java-repo-tools/ --no-commit java-repo-tools
+git pull -s subtree java-repo-tools master
 ```
 
 Then you can make any needed changes to make the rest of the repository
@@ -170,6 +163,10 @@ git push java-repo-tools java-repo-tools:name-for-remote-branch
 
 Then, you can send a pull request to the `java-repo-tools` repository.
 
+
+## References
+
+- [GitHub's subtree merge reference](https://help.github.com/articles/about-git-subtree-merges/)
 
 ## Contributing changes
 

--- a/java/java-repo-tools/google-checks.xml
+++ b/java/java-repo-tools/google-checks.xml
@@ -167,9 +167,9 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.google"/>
+            <property name="specialImportsRegExp" value="^javax\."/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+            <property name="customImportOrderRules" value="STATIC###SAME_PACKAGE(2)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">


### PR DESCRIPTION
Sorry for so many commits. I missed the step of merging histories when I first pulled in the `java-repo-tools` subtree. Without it, pulling updates from upstream always conflict.

I ran the following commands: Create a new branch.

```
git checkout master
git pull origin master
git checkout -b update-java-repo-tools
```

Merge histories (this should only need to be done once).

```
git merge -s ours --no-commit java-repo-tools/master
git status
git commit
```

Verify that there are differences with current head, so yes I do need to pull those changes in.

```
git fetch java-repo-tools master
cd java
git diff-tree -p HEAD:./java-repo-tools/ java-repo-tools/master
```

Pull in the latest changes, using the subtree merge strategy. (Should be smart enough to figure out the directory. If not, you can use the [recursive strategy which takes a subtree path argument](https://www.kernel.org/pub/software/scm/git/docs/git-merge.html).)

```
git pull -s subtree java-repo-tools master
```
 
Test that everything still works with the new configuration.

```
GOOGLE_APPLICATION_CREDENTIALS=~/src/vision/client-secret.json mvn clean verify
```