### PR TITLE
Replaces hardcoded /usr/bin/python to use env python

### DIFF
--- a/python/face_detection/faces.py
+++ b/python/face_detection/faces.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright 2015 Google, Inc
 #

--- a/python/landmark_detection/detect_landmark.py
+++ b/python/landmark_detection/detect_landmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright 2016 Google, Inc
 #

--- a/python/utils/generatejson.py
+++ b/python/utils/generatejson.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright 2016 Google, Inc
 #


### PR DESCRIPTION
Hey Guys, 

Just update a few hashbangs from `/usr/bin/python` to `/usr/bin/env python` so samples are virtualenv friendly.