### PR TITLE
Fixes missing x/y vertices for edge cases

### DIFF
--- a/python/face_detection/faces.py
+++ b/python/face_detection/faces.py
@@ -84,7 +84,7 @@ def highlight_faces(image, faces, output_filename):
     draw = ImageDraw.Draw(im)
 
     for face in faces:
-        box = [(v['x'], v['y']) for v in face['fdBoundingPoly']['vertices']]
+        box = [(v.get('x', 0.0), v.get('y', 0.0)) for v in face['fdBoundingPoly']['vertices']]
         draw.line(box + [box[0]], width=5, fill='#00ff00')
 
     del draw


### PR DESCRIPTION
API will omit `x` or `y` value for edge cases (i.e when part of the face's bounding box is outside the image), patch sets a `0.0` default for such cases, so the bounding box can still be drawn in the sample output images.  

For example, [this image](https://storage.googleapis.com/admobilize-shared-folder/Edison.jpg) will produce the following vertices : 

```
  "boundingPoly": {
      "vertices": [
       {
       },
       {
        "x": 959
       },
       {
        "x": 959,
        "y": 1279
       },
       {
        "y": 1279
       }
      ]
     },
     "fdBoundingPoly": {
      "vertices": [
       {
        "y": 417
       },
       {
        "x": 959,
        "y": 417
       },
       {
        "x": 959,
        "y": 1279
       },
       {
        "y": 1279
       }
      ]
     }
```