### PR TITLE
Notify that Java samples have moved to java-docs-samples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ env:
   - CONFIG=android_jdk8
   - CONFIG=android_oracle8
   - CONFIG=go
-  - CONFIG=java_jdk8
-  - CONFIG=java_oracle8
   - CONFIG=php
 matrix:
   exclude:
@@ -55,10 +53,6 @@ matrix:
     env: CONFIG=android_jdk8
   - os: osx
     env: CONFIG=android_oracle8
-  - os: osx
-    env: CONFIG=java_jdk8
-  - os: osx
-    env: CONFIG=java_oracle8
   # Add into the matrix OS X tests of iOS samples (needs Xcode, so it won't
   # work on other platforms). These are split so it doesn't take as long to run
   include:

--- a/java/README.md
+++ b/java/README.md
@@ -1,3 +1,12 @@
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+The Google Cloud Vision API Java samples have moved. This directory is no longer
+actively developed or maintained.
+
+For new work on this check out the
+[vision samples](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/vision)
+in the Google Cloud Platform Java samples repository.
+
 # Google Cloud Vision API Java examples
 
 This directory contains [Cloud Vision API](https://cloud.google.com/vision/) Java samples.

--- a/java/face_detection/README.md
+++ b/java/face_detection/README.md
@@ -1,3 +1,12 @@
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+The Google Cloud Vision API Java samples have moved. This directory is no longer
+actively developed or maintained.
+
+For new work on this check out the
+[face detection vision sample](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/vision/face-detection)
+in the Google Cloud Platform Java samples repository.
+
 # Google Cloud Vision API Java Face Detection example
 
 ## Download Maven

--- a/java/label/README.md
+++ b/java/label/README.md
@@ -1,3 +1,12 @@
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+The Google Cloud Vision API Java samples have moved. This directory is no longer
+actively developed or maintained.
+
+For new work on this check out the
+[image labeling vision sample](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/vision/label)
+in the Google Cloud Platform Java samples repository.
+
 # Google Cloud Vision API Java Image Labeling example
 
 ## Download Maven

--- a/java/landmark_detection/README.md
+++ b/java/landmark_detection/README.md
@@ -1,3 +1,12 @@
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+The Google Cloud Vision API Java samples have moved. This directory is no longer
+actively developed or maintained.
+
+For new work on this check out the
+[landmark detection vision sample](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/vision/landmark-detection)
+in the Google Cloud Platform Java samples repository.
+
 # Google Cloud Vision API Java Landmark Detection example
 
 This sample takes in the URI for an object in Google Cloud Storage, and

--- a/java/text/README.md
+++ b/java/text/README.md
@@ -1,3 +1,12 @@
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+The Google Cloud Vision API Java samples have moved. This directory is no longer
+actively developed or maintained.
+
+For new work on this check out the
+[text vision sample](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/vision/text)
+in the Google Cloud Platform Java samples repository.
+
 # Text Detection using the Vision API
 
 This sample requires Java 8.


### PR DESCRIPTION
Also, disable tests for the Java samples in the Travis configuration. I have already sent a change request to update the doc location to java-docs-samples.

Samples were added to java-docs-samples in https://github.com/GoogleCloudPlatform/java-docs-samples/pull/228.